### PR TITLE
Non-zero exit code if filter does not match

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -129,7 +129,16 @@ do
 
 	# Print the formatted entry
 	echo "Bus $bus_num Device$device_num: ID $VID:$PID $manufacturer $name $serial_str"
+
+	(( counter++ ))
 done
 
 # Restore the IFS
 IFS=$OIFS
+
+# A specific device was requested, but it was not found
+if [ -n "$vid_pid" -a $counter -eq 0 ]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This is the same behavior that lsusb from util-linux implements and
allows to easily check for the availability of a specific device.
