### PR TITLE
handle empty bus_num

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -85,9 +85,13 @@ parse ()  {
 		esac
 	fi
 
-	# Convert bus number from hexadecimal to decimal.
-	bus_num=`echo "$((16#$bus_num))"`
-        bus_num=`printf "%0*d" 3 "$bus_num"`
+  if [ ${#bus_num} -ne 0 ]; then
+    # Convert bus number from hexadecimal to decimal.
+    bus_num=`echo "$((16#$bus_num))"`
+    bus_num=`printf "%0*d" 3 "$bus_num"`
+  else
+    bus_num='---'
+  fi
 
 	# Strip the parentheses from manufacturer name unless so specified.
 	if [ -z "$parens" ]; then	

--- a/lsusb
+++ b/lsusb
@@ -4,7 +4,7 @@
 #
 # Disclaimer: usage info and functionality from lsusb under Linux
 
-verbose () { system_profiler SPUSBDataType; }
+verbose () { system_profiler SPUSBDataType 2>/dev/null; }
 version () { echo "lsusb for Mac OS X 007"; }
 help ()  {
   cat >&2 <<EOM


### PR DESCRIPTION
When `$bus_num` is empty (e.g. in case of `05ac:8102 Apple Inc. Apple T2 Bus`), the script throws the following error:

```bash
/usr/local/bin/lsusb: line 89: 16#: invalid integer constant (error token is "16#")
```

because it is not possible to treat an empty variable as a hexadecimal and convert it into an integer. My fix handles the situation by printing `---` when the bus number is not provided.