### PR TITLE
Fix device parsing broken by quoted loop substitutions, plus Tahoe issues

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -72,9 +72,18 @@ parse ()  {
 	bus_num=`echo "$location" |  sed -e 's/^..\(..\).*/\1/;'`
 
 	# Get the device number. It's after the '/' in the Location ID, already decimal.
-	# Tahoe breaks this format, and we don't have a device number.
+	# Tahoe no longer reports it there, but the bus address still exists in
+	# the IO Registry, so look it up by Location ID (000 if not found).
 	device_num=`echo "$location" | awk -F'/' '{print $2}'`
-	device_num=`printf "%0*d" 3 "$device_num"`
+	if [ -z "$device_num" ] && [ -n "$location" ]; then
+		if [ -z "$dev_addresses" ]; then
+			dev_addresses=`get_dev_addresses`
+		fi
+		loc_key=`echo "$location" | sed 's/^0x0*//'`
+		addr_hex=`echo "$dev_addresses" | awk -v loc="$loc_key" '$1 == loc { print $2; exit }'`
+		device_num=$((16#${addr_hex:-0}))
+	fi
+	device_num=`printf "%0*d" 3 "${device_num:-0}"`
 
 	# Strip off the excess from LocationID for sorting tree.
 	locationID=`echo "$location" | awk -F'/' '{print $1}'`
@@ -233,6 +242,22 @@ get_devices() {
 
 get_buses() {
 	<<<"$rawlog" awk -v first=1 '/Bus:$/ { flag = 1; if (first == 1) { first = 0 } else { print "#" }; print; next }; /:$/ && flag == 1 { flag = 0 }; flag'
+}
+
+get_dev_addresses() {
+	# Map each device's Location ID to its USB bus address from the IO
+	# Registry. Tahoe's system_profiler no longer reports device numbers
+	# (the pre-Tahoe "Location ID: 0x... / dev" suffix), but the addresses
+	# still exist in the IOUSB plane. Emit one "locationID address" pair
+	# per device, both in hex with the 0x prefix and leading zeros stripped.
+	ioreg -p IOUSB -l -x 2>/dev/null | awk '
+		/"locationID" = 0x/ { loc = $NF; sub(/^0x0*/, "", loc) }
+		/"USB Address" = 0x/ { addr = $NF; sub(/^0x0*/, "", addr) }
+		/^[ |]*}[ ]*$/ {
+			if (loc != "" && addr != "") { print loc " " addr }
+			loc = ""
+			addr = ""
+		}'
 }
 
 buildtreeline () {

--- a/lsusb
+++ b/lsusb
@@ -65,7 +65,7 @@ parse ()  {
 	fi
 
 	# Get the Location Id
-	location=`echo "$device" | egrep -A7 "$name" | egrep "Location ID" | tail -1 | sed -e 's/Location ID://; s/^ *//g; s/ *$//g;'`
+	location=`echo "$device" | egrep "Location ID" | tail -1 | sed -e 's/Location ID://; s/^ *//g; s/ *$//g;'`
 
 	# Get the bus number. It's the first two hex digits of the Location ID.
 	# We'll convert to decimal later
@@ -86,10 +86,15 @@ parse ()  {
 		fi
 
 		# Get the bus number, in hexadecimal. We'll convert to decimal later.
-		bus_num=`echo "$device" | egrep "Bus Number" | sed -e 's/Bus Number://' -e 's/0x//; s/^ *//g' -e 's/ *$//g'`
+		# Tahoe has no Bus Number line; keep the bus number already taken
+		# from the Location ID instead.
+		bus_hex=`echo "$device" | egrep "Bus Number" | sed -e 's/Bus Number://' -e 's/0x//; s/^ *//g' -e 's/ *$//g'`
+		if [ -n "$bus_hex" ]; then
+			bus_num="$bus_hex"
 
-		# Create a fake Location ID for sorting purposes, following the model.
-		locationID="0x${bus_num}000000"
+			# Create a fake Location ID for sorting purposes, following the model.
+			locationID="0x${bus_num}000000"
+		fi
 
 		# Device Number is always 1.
 		device_num="001"
@@ -99,11 +104,11 @@ parse ()  {
 		manufacturer="(Apple Inc.)"
 
 		# The PID depends on the speed of the hub, which we deduce from the controller driver.
-		PID=`echo "$device" | egrep "(Controller)? Driver:" | awk -F':' '{print $2}' | tail -1 | sed -e 's/0x//; s/^ *//g' -e 's/ *$//g; s/.*\(....\)$/\1/'`
-	  	case "$PID" in
-			OHCI) PID="8005"; name="OHCI Root Hub Simulation"; speed="12M" ;;
-			EHCI) PID="8006"; name="EHCI Root Hub Simulation"; speed="480M" ;;
-			XHCI) PID="8007"; name="XHCI Root Hub USB 2.0 Simulation"; speed="5000M" ;;
+		driver=`echo "$device" | egrep "(Controller)? Driver:" | awk -F':' '{print $2}' | tail -1`
+	  	case "$driver" in
+			*OHCI*) PID="8005"; name="OHCI Root Hub Simulation"; speed="12M" ;;
+			*EHCI*) PID="8006"; name="EHCI Root Hub Simulation"; speed="480M" ;;
+			*XHCI*) PID="8007"; name="XHCI Root Hub USB 2.0 Simulation"; speed="5000M" ;;
 		esac
 	fi
 
@@ -210,8 +215,20 @@ cleanup () {
 }
 
 get_devices() {
-	<<<"$rawlog" sed -e '/:$/i\
-#'
+	# Split the log into sections at each "name:" line and emit only the
+	# sections that contain a Product ID line (i.e. actual devices),
+	# separated by '#' lines. Buses are handled by get_buses.
+	<<<"$rawlog" awk -v first=1 '
+		function emit() {
+			if (buf ~ /Product ID/) {
+				if (first == 1) { first = 0 } else { print "#" }
+				printf "%s", buf
+			}
+			buf = ""
+		}
+		/:$/ { emit() }
+		{ buf = buf $0 "\n" }
+		END { emit() }'
 }
 
 get_buses() {
@@ -229,9 +246,14 @@ buildtreeline () {
 # So we start each line with the LocationID for sorting purposes, then append the rest of the line as we want it
 # Later, we'll do the sort, then strip off the LocationID for display purposes
 
-	spaces=`echo "$locationID" | sed 's/^0x...//; s/0//g; s/./ /g; s/.*/&&&&/'`
+	# Strip any trailing space left over from the pre-Tahoe "0x... / dev" format.
+	locationID=`echo "$locationID" | sed 's/ *$//'`
+
+	# Indent four spaces per tree level: after the 0x prefix and two-digit
+	# bus number, each nonzero digit is one level deep.
+	spaces=`echo "$locationID" | sed 's/^0x..//; s/[^1-9a-fA-F]//g; s/./    /g'`
 	if [ ${#spaces} -eq 0 ]; then
-		spaces=" /:  "
+		spaces="/:  "
 	else
 		spaces="${spaces}|__ "
 	fi
@@ -242,7 +264,7 @@ tree () {
 	setup
 	treeflag="yes"
 
-	for device in "$(get_devices)"
+	for device in $(get_devices)
 	do
 		# Skip null device lines
 		if [ "${#device}" -ne 1 ]; then
@@ -252,7 +274,7 @@ tree () {
 		fi
 	done
 
-	for device in "$(get_buses)"
+	for device in $(get_buses)
 	do
 		parse
 		buildtreeline
@@ -265,10 +287,10 @@ tree () {
 	# Sort by Location ID.
 	treedata=`echo "${treedata}" | sort`
 
-	# Now strip off leading Location ID and print to stdout.
+	# Now strip off the leading 10-character Location ID and print to stdout.
 	for line in $treedata
 	do
-		echo "$line" | sed 's/^...........//'
+		echo "$line" | sed 's/^..........//'
 	done
 
 	# Restore the IFS
@@ -327,7 +349,7 @@ setup
 # will not be interfered
 
 # Iterate over each entry
-for device in "$(get_devices)"
+for device in $(get_devices)
 do
 	parse
 	if [ $? -eq 0 ]; then
@@ -336,7 +358,7 @@ do
 	fi
 done
 
-for device in "$(get_buses)"
+for device in $(get_buses)
 do
 	parse
 	if [ $? -eq 0 ]; then


### PR DESCRIPTION
## The bug

Since b2544b7, the flat listing collapses into a single mashed line containing every device's VID and serial number:

```
Bus 008 Device 000: ID 05e3
1532
05ac
...
d009 GenesysLogic Alpha Imaging Tech. Corp. Apple Inc. Logitech ... Serial: Not Provided
Not Provided
F0T3416RFL01C7TAZ
...
```

That commit changed the device loops from `for device in $devices` to `for device in "$(get_devices)"`. The quotes prevent the `IFS='#'` word-splitting the script relies on to separate device entries, so the entire `system_profiler` output is parsed as **one** device. This affects all macOS versions, not just Tahoe.

## Fixes

1. **Unquote the four loop command substitutions** (two in `tree()`, two in the main body) so IFS splitting works again.

2. **`get_devices` now only emits sections containing a `Product ID` line.** On Tahoe, the top-level `USB:` header and `USB 3.x Bus:` sections also end in `:` and were chunked as devices, producing a garbage `ID 05ac:` header line and printing every bus twice. This also excludes pre-Tahoe `Media:`/`Volumes:` storage subsections.

3. **Root-hub bus numbers:** Tahoe bus sections have no `Bus Number:` line (they carry a `Location ID` instead), so every bus printed as `Bus 000`. Keep the bus number already derived from the Location ID when `Bus Number` is absent.

4. **Root-hub PID detection:** match `OHCI`/`EHCI`/`XHCI` anywhere in the driver name instead of its last four characters, which broke on drivers like `AppleEmbeddedUSBXHCIASMedia3142` (gave PID `3142`) and `AppleUSBEHCIPCI` (gave PID `IPCI`).

5. **Tree-mode indentation:** the depth calculation silently depended on the trailing space left by the pre-Tahoe `0x14100000 / 21` location format. Tahoe dropped the ` / devnum` suffix, so every device rendered one level too shallow (top-level hubs appeared as buses). Count nonzero level digits explicitly and normalize the Location ID — works for both formats.

6. **Drop the fragile `egrep -A7 "$name"`** when extracting the Location ID; each chunk is now a single device, and device names containing regex metacharacters broke the pattern.

## Verification

On Tahoe (26.5.1, Apple Silicon, 7 buses / 18 devices including nested hubs):

```
$ ./lsusb
Bus 001 Device 000: ID 05e3:0610 GenesysLogic USB2.1 Hub  Serial: Not Provided
Bus 001 Device 000: ID 1532:0e03 Alpha Imaging Tech. Corp. Razer Kiyo  Serial: Not Provided
...
Bus 008 Device 001: ID 05ac:8007 Apple Inc. XHCI Root Hub USB 2.0 Simulation

$ ./lsusb -t
/:  Bus 001.Dev 001: XHCI Root Hub USB 2.0 Simulation, 5000M
    |__ Bus 001.Dev 000: USB2.1 Hub, 480Mb/s
        |__ Bus 001.Dev 000: Razer Kiyo, 480Mb/s
...
```

For pre-Tahoe, since `setup()` only populates `$rawlog` when unset, I ran both this branch and e1bfd60 (last commit before the Tahoe rework) against a canned Sonoma-format `SPUSBDataType` fixture (Intel-style `Bus Number:` lines, `/ devnum` location suffixes, a `Media:`/`Volumes:` storage device, nested hub). Output is identical except for the intentional manufacturer-line preference from f40fb20 and the EHCI root-hub fix above. Device numbers from the `/ N` suffix, `Bus Number` parsing, tree indentation depths, `-d`/`-s`/`-p` filters, and exit codes all match the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)